### PR TITLE
Add support for Ruby 3.2 and drop support for Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ workflows:
               ruby_version:
                 - "2.7.7"
                 - "3.0.5"
+                - "3.1.3"
+                - "3.2.0"
 version: 2.1
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,13 @@ workflows:
   build:
     jobs:
       - lint:
-          ruby_version: "2.7.2"
+          ruby_version: "2.7.7"
       - test:
           matrix:
             parameters:
               ruby_version:
-                - "2.6.5"
-                - "2.7.2"
-                - "3.0.0"
+                - "2.7.7"
+                - "3.0.5"
 version: 2.1
 jobs:
   lint:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   salsify_rubocop: conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     # IntelliJ compile target directory
     - 'out/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 3.0.0 - 2023-01-20
+### Changed
+- Drop support for Ruby 2.6
+
 ## 2.0.0 - 2021-03-31
 ### Changed
 - Require Ruby 2.6+

--- a/delayed_job_chainable_hooks.gemspec
+++ b/delayed_job_chainable_hooks.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'activesupport', '>= 5.2'
   spec.add_dependency 'delayed_job', '>= 4.1'
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '>= 3.8'
   spec.add_development_dependency 'rspec_junit_formatter'
-  spec.add_development_dependency 'salsify_rubocop', '~> 1.0.2'
+  spec.add_development_dependency 'salsify_rubocop', '~> 1.43.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'sqlite3'
 end

--- a/lib/delayed_job_chainable_hooks/version.rb
+++ b/lib/delayed_job_chainable_hooks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DelayedJobChainableHooks
-  VERSION = '2.0.0'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
This PR adds support for Ruby 3.2 and drops support for Ruby 2.6 as it is EOL.

prime: @jturkel 